### PR TITLE
[FLINK-29246] Adding skeleton project files and checkstyle configuration

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -1,0 +1,86 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+labelPRBasedOnFilePath:
+  component=BuildSystem:
+    - .github/**/*
+    - tools/maven/*
+
+  component=Documentation:
+    - docs/**/*
+
+  component=Connectors/DynamoDB:
+    - flink-connector-aws-dynamodb*/**/*
+    - flink-sql-connector-aws-dynamodb*/**/*
+
+###### IssueLink Adder #################################################################################################
+# Insert Issue (Jira/Github etc) link in PR description based on the Issue ID in PR title.
+insertIssueLinkInPrDescription:
+  # specify the placeholder for the issue link that should be present in the description
+  descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
+  matchers:
+    # you can have several matches - for different types of issues
+    # only the first matching entry is replaced
+    jiraIssueMatch:
+      # specify the regexp of issue id that you can find in the title of the PR
+      # the match groups can be used to build the issue id (${1}, ${2}, etc.).
+      titleIssueIdRegexp: \[(FLINK-[0-9]+)\]
+      # the issue link to be added. ${1}, ${2} ... are replaced with the match groups from the
+      # title match (remember to use quotes)
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/)"
+    docOnlyIssueMatch:
+      titleIssueIdRegexp: \[hotfix\]
+      descriptionIssueLink: "`Documentation only change, no JIRA issue`"
+
+###### Title Validator #################################################################################################
+# Verifies if commit/PR titles match the regexp specified
+verifyTitles:
+  # Regular expression that should be matched by titles of commits or PR
+  titleRegexp: ^\[FLINK-[0-9]+\].*$|^\[FLINK-XXXXX\].*$|^\[hotfix].*$
+  # If set to true, it will always check the PR title (as opposed to the individual commits).
+  alwaysUsePrTitle: false
+  # If set to true, it will only check the commit in case there is a single commit.
+  # In case of multiple commits it will check PR title.
+  # This reflects the standard behaviour of Github that for `Squash & Merge` GitHub
+  # uses the PR title rather than commit messages for the squashed commit ¯\_(ツ)_/¯
+  # For single-commit PRs it takes the squashed commit message from the commit as expected.
+  #
+  # If set to false it will check all commit messages. This is useful when you do not squash commits at merge.
+  validateEitherPrOrSingleCommitTitle: true
+  # The title the GitHub status should appear from.
+  statusTitle: "Title Validator"
+  # A custom message to be displayed when the title passes validation.
+  successMessage: "Validation successful!"
+  # A custom message to be displayed when the title fails validation.
+  # Allows insertion of ${type} (commit/PR), ${title} (the title validated) and ${regex} (the titleRegexp above).
+  failureMessage: "Wrong ${type} title: ${title}"
+
+# Various Flags to control behaviour of the "Labeler"
+labelerFlags:
+  # If this flag is changed to 'false', labels would only be added when the PR is first created
+  # and not when existing PR is updated.
+  # The default is 'true' which means the labels would be added when PR is updated even if they
+  # were removed by the user
+  labelOnPRUpdates: true
+
+# Comment to be posted to welcome users when they open their first PR
+firstPRWelcomeComment: >
+  Thanks for opening this pull request! Please check out our contributing guidelines. (https://flink.apache.org/contributing/how-to-contribute.html)
+# Comment to be posted to congratulate user on their first merged PR
+firstPRMergeComment: >
+  Awesome work, congrats on your first merged pull request!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+name: Build flink-connector-dynamodb
+on: [push, pull_request]
+jobs:
+  compile_and_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: [8, 11]
+    env:
+      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+    steps:
+      - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
+
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Set JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.jdk }}
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Set Maven 3.8.5
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: 3.8.5
+
+      - name: Compile and test flink-connector-dynamodb
+        run: mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }}

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/flink-connector-aws-dynamodb/pom.xml
+++ b/flink-connector-aws-dynamodb/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.flink</groupId>
+        <artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>flink-connector-aws-dynamodb</artifactId>
+    <name>Flink : Connectors : Amazon DynamoDB</name>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-test-utils-junit</artifactId>
+				<version>${flink.version}</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+</project>

--- a/flink-sql-connector-aws-dynamodb/pom.xml
+++ b/flink-sql-connector-aws-dynamodb/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>flink-sql-connector-aws-dynamodb</artifactId>
+	<name>Flink : Connectors : SQL : Amazon DynamoDB</name>
+	<packaging>jar</packaging>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-test-utils-junit</artifactId>
+				<version>${flink.version}</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-aws-dynamodb</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
+									<include>org.apache.flink:flink-connector-aws-base</include>
+									<include>org.apache.flink:flink-connector-aws-dynamodb</include>
+									<include>software.amazon.awssdk:*</include>
+									<include>org.reactivestreams:*</include>
+									<include>com.typesafe.netty:*</include>
+									<include>org.apache.httpcomponents:*</include>
+									<include>io.netty:*</include>
+									<include>commons-logging:commons-logging</include>
+								</includes>
+							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>software.amazon</pattern>
+									<shadedPattern>org.apache.flink.connector.dynamodb.shaded.software.amazon</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.reactivestreams</pattern>
+									<shadedPattern>org.apache.flink.connector.dynamodb.shaded.org.reactivestreams</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.typesafe.netty</pattern>
+									<shadedPattern>org.apache.flink.connector.dynamodb.shaded.com.typesafe.netty</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.apache.http</pattern>
+									<shadedPattern>org.apache.flink.connector.dynamodb.shaded.org.apache.http</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>io.netty</pattern>
+									<shadedPattern>org.apache.flink.connector.dynamodb.shaded.io.netty</shadedPattern>
+								</relocation>
+							</relocations>
+							<filters>
+								<filter>
+									<artifact>org.apache.flink:flink-connector-aws-dynamodb:*</artifact>
+									<excludes>
+										<exclude>profile</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>org.apache.flink:flink-connector-aws-base:*</artifact>
+									<excludes>
+										<exclude>profile</exclude>
+									</excludes>
+								</filter>
+							</filters>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.15.2</version>
+		<relativePath/>
+	</parent>
+
+	<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+
+	<name>Flink : Connectors : Amazon DynamoDB Parent</name>
+	<packaging>pom</packaging>
+	<url>https://flink.apache.org</url>
+	<inceptionYear>2022</inceptionYear>
+
+	<licenses>
+		<license>
+			<name>The Apache Software License, Version 2.0</name>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<scm>
+		<url>https://github.com/apache/flink-connector-dynamodb</url>
+		<connection>git@github.com:apache/flink-connector-dynamodb.git</connection>
+		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-dynamodb.git</developerConnection>
+	</scm>
+
+	<properties>
+		<aws.sdk.version>2.17.247</aws.sdk.version>
+		<flink.version>1.15.2</flink.version>
+	</properties>
+
+	<modules>
+		<module>flink-connector-aws-dynamodb</module>
+		<module>flink-sql-connector-aws-dynamodb</module>
+	</modules>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws.sdk.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-test-utils-junit</artifactId>
+				<version>${project.parent.version}</version>
+				<scope>test</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<plugins>
+			<plugin>
+				<!-- Override directory for parent project -->
+				<groupId>org.commonjava.maven.plugins</groupId>
+				<artifactId>directory-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>directories</id>
+						<goals>
+							<goal>directory-of</goal>
+						</goals>
+						<configuration>
+							<property>rootDir</property>
+							<project>
+								<groupId>org.apache.flink</groupId>
+								<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+							</project>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -1,0 +1,567 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE module PUBLIC
+	"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+	"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+This is a checkstyle configuration file. For descriptions of
+what the following rules do, please see the checkstyle configuration
+page at http://checkstyle.sourceforge.net/config.html.
+
+This file is based on the checkstyle file of Apache Beam.
+-->
+
+<module name="Checker">
+
+	<module name="NewlineAtEndOfFile">
+		<!-- windows can use \r\n vs \n, so enforce the most used one ie UNIx style -->
+		<property name="lineSeparator" value="lf"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
+		<property name="format" value="((//.*)|(\*.*))TODO\("/>
+		<property name="message" value="TODO comments must not include usernames."/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="\s+$"/>
+		<property name="message" value="Trailing whitespace"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<module name="RegexpSingleline">
+		<property name="format" value="Throwables.propagate\("/>
+		<property name="message" value="Throwables.propagate is deprecated"/>
+		<property name="severity" value="error"/>
+	</module>
+
+	<!-- Prevent *Tests.java as tools may not pick them up -->
+	<!--<module name="RegexpOnFilename">-->
+	<!--<property name="fileNamePattern" value=".*Tests\.java$" />-->
+	<!--</module>-->
+
+	<module name="SuppressionFilter">
+		<property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml"/>
+	</module>
+
+	<!-- Check that every module has a package-info.java -->
+	<!--<module name="JavadocPackage"/>-->
+
+	<!--
+
+	FLINK CUSTOM CHECKS
+
+	-->
+
+	<module name="FileLength">
+		<property name="max" value="3000"/>
+	</module>
+
+	<!-- All Java AST specific tests live under TreeWalker module. -->
+	<module name="TreeWalker">
+
+		<!-- Allow use of comment to suppress javadocstyle -->
+		<module name="SuppressionCommentFilter">
+			<property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+			<property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+			<property name="checkFormat" value="$1"/>
+		</module>
+
+		<!--
+
+		FLINK CUSTOM CHECKS
+
+		-->
+
+		<!-- Prohibit T.getT() methods for standard boxed types -->
+		<module name="Regexp">
+			<property name="format" value="Boolean\.getBoolean"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Integer\.getInteger"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<module name="Regexp">
+			<property name="format" value="Long\.getLong"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use System.getProperties() to get system properties."/>
+		</module>
+
+		<!--
+
+		IllegalImport cannot blacklist classes so we have to fall back to Regexp.
+
+		-->
+
+		<!-- forbid use of commons lang validate -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.Validate"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Guava Checks instead of Commons Validate. Please refer to the coding guidelines."/>
+		</module>
+		<!-- forbid the use of google.common.base.Preconditions -->
+		<module name="Regexp">
+			<property name="format" value="import com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<!-- forbid the use of com.google.common.annotations.VisibleForTesting -->
+		<module name="Regexp">
+			<property name="format"
+					  value="import com\.google\.common\.annotations\.VisibleForTesting"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's VisibleForTesting instead of Guava's VisibleForTesting"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="import static com\.google\.common\.base\.Preconditions"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's Preconditions instead of Guava's Preconditions"/>
+		</module>
+		<!-- forbid the use of org.apache.commons.lang.SerializationUtils -->
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang3\.SerializationUtils"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message"
+					  value="Use Flink's InstantiationUtil instead of common's SerializationUtils"/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.apache\.commons\.lang\."/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use commons-lang3 instead of commons-lang."/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.codehaus\.jettison"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use com.fasterxml.jackson instead of jettison."/>
+		</module>
+		<module name="Regexp">
+			<property name="format" value="org\.testcontainers\.shaded"/>
+			<property name="illegalPattern" value="true"/>
+			<property name="message" value="Use utilities from appropriate library instead of org.testcontainers."/>
+		</module>
+
+		<!-- Enforce Java-style array declarations -->
+		<module name="ArrayTypeStyle"/>
+
+		<module name="TodoComment">
+			<!-- Checks that disallowed strings are not used in comments.  -->
+			<property name="format" value="(FIXME)|(XXX)|(@author)"/>
+		</module>
+
+		<!--
+
+		IMPORT CHECKS
+
+		-->
+
+		<module name="RedundantImport">
+			<!-- Checks for redundant import statements. -->
+			<property name="severity" value="error"/>
+			<message key="import.redundancy"
+					 value="Redundant import {0}."/>
+		</module>
+
+		<module name="ImportOrder">
+			<!-- Checks for out of order import statements. -->
+			<property name="severity" value="error"/>
+			<property name="groups"
+					  value="org.apache.flink,org.apache.flink.shaded,*,javax,java,scala"/>
+			<property name="separated" value="true"/>
+			<property name="sortStaticImportsAlphabetically" value="true"/>
+			<property name="option" value="bottom"/>
+			<property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+			<message key="import.ordering"
+					 value="Import {0} appears after other imports that it should precede"/>
+		</module>
+
+		<module name="AvoidStarImport">
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="IllegalImport">
+			<property name="illegalPkgs"
+					  value="autovalue.shaded, avro.shaded, com.google.api.client.repackaged, com.google.appengine.repackaged"/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.codehaus.jackson"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-jackson instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="org.objectweb.asm"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-asm instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="io.netty"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-netty instead."/>
+		</module>
+		<module name="IllegalImport">
+			<property name="illegalPkgs" value="com.google.common"/>
+			<message key="import.illegal" value="{0}; Use flink-shaded-guava instead."/>
+		</module>
+
+		<module name="RedundantModifier">
+			<!-- Checks for redundant modifiers on various symbol definitions.
+			  See: http://checkstyle.sourceforge.net/config_modifier.html#RedundantModifier
+
+			  We exclude METHOD_DEF to allow final methods in final classes to make them more future-proof.
+			-->
+			<property name="tokens"
+					  value="VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+		</module>
+
+		<!--
+			IllegalImport cannot blacklist classes, and c.g.api.client.util is used for some shaded
+			code and some useful code. So we need to fall back to Regexp.
+		-->
+		<!--<module name="RegexpSinglelineJava">-->
+		<!--<property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>-->
+		<!--</module>-->
+
+		<!--
+			 Require static importing from Preconditions.
+		-->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value="^import com.google.common.base.Preconditions;$"/>
+			<property name="message" value="Static import functions from Guava Preconditions"/>
+		</module>
+
+		<module name="UnusedImports">
+			<property name="severity" value="error"/>
+			<property name="processJavadoc" value="true"/>
+			<message key="import.unused"
+					 value="Unused import: {0}."/>
+		</module>
+
+		<!--
+
+		JAVADOC CHECKS
+
+		-->
+
+		<!-- Checks for Javadoc comments.                     -->
+		<!-- See http://checkstyle.sf.net/config_javadoc.html -->
+		<module name="JavadocMethod">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingJavadoc" value="true"/>
+			<property name="allowMissingParamTags" value="true"/>
+			<property name="allowMissingReturnTag" value="true"/>
+			<property name="allowMissingThrowsTags" value="true"/>
+			<property name="allowThrowsTagsForSubclasses" value="true"/>
+			<property name="allowUndeclaredRTE" value="true"/>
+			<!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
+			<property name="suppressLoadErrors" value="true"/>
+		</module>
+
+		<!-- Check that paragraph tags are used correctly in Javadoc. -->
+		<module name="JavadocParagraph"/>
+
+		<module name="JavadocType">
+			<property name="scope" value="protected"/>
+			<property name="severity" value="error"/>
+			<property name="allowMissingParamTags" value="true"/>
+		</module>
+
+		<module name="JavadocStyle">
+			<property name="severity" value="error"/>
+			<property name="checkHtml" value="true"/>
+		</module>
+
+		<!--
+
+		NAMING CHECKS
+
+		-->
+
+		<!-- Item 38 - Adhere to generally accepted naming conventions -->
+
+		<module name="PackageName">
+			<!-- Validates identifiers for package names against the
+			  supplied expression. -->
+			<!-- Here the default checkstyle rule restricts package name parts to
+			  seven characters, this is not in line with common practice at Google.
+			-->
+			<property name="format" value="^[a-z]+(\.[a-z][a-z0-9]{1,})*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="TypeNameCheck">
+			<!-- Validates static, final fields against the
+			expression "^[A-Z][a-zA-Z0-9]*$". -->
+			<metadata name="altname" value="TypeName"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ConstantNameCheck">
+			<!-- Validates non-private, static, final fields against the supplied
+			public/package final fields "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$". -->
+			<metadata name="altname" value="ConstantName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="false"/>
+			<property name="format" value="^([A-Z][A-Z0-9]*(_[A-Z0-9]+)*|FLAG_.*)$"/>
+			<message key="name.invalidPattern"
+					 value="Variable ''{0}'' should be in ALL_CAPS (if it is a constant) or be private (otherwise)."/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="StaticVariableNameCheck">
+			<!-- Validates static, non-final fields against the supplied
+			expression "^[a-z][a-zA-Z0-9]*_?$". -->
+			<metadata name="altname" value="StaticVariableName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*_?$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MemberNameCheck">
+			<!-- Validates non-static members against the supplied expression. -->
+			<metadata name="altname" value="MemberName"/>
+			<property name="applyToPublic" value="true"/>
+			<property name="applyToProtected" value="true"/>
+			<property name="applyToPackage" value="true"/>
+			<property name="applyToPrivate" value="true"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="MethodNameCheck">
+			<!-- Validates identifiers for method names. -->
+			<metadata name="altname" value="MethodName"/>
+			<property name="format" value="^[a-z][a-zA-Z0-9]*(_[a-zA-Z0-9]+)*$"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="ParameterName">
+			<!-- Validates identifiers for method parameters against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalFinalVariableName">
+			<!-- Validates identifiers for local final variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="LocalVariableName">
+			<!-- Validates identifiers for local variables against the
+			  expression "^[a-z][a-zA-Z0-9]*$". -->
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Type parameters must be either one of the four blessed letters
+		T, K, V, W, X or else be capital-case terminated with a T,
+		such as MyGenericParameterT -->
+		<!--<module name="ClassTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="MethodTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--<module name="InterfaceTypeParameterName">-->
+		<!--<property name="format" value="^(((T|K|V|W|X)[0-9]*)|([A-Z][a-z][a-zA-Z]*T))$"/>-->
+		<!--<property name="severity" value="error"/>-->
+		<!--</module>-->
+
+		<!--
+
+		LENGTH and CODING CHECKS
+
+		-->
+
+		<!--<module name="LineLength">-->
+		<!--&lt;!&ndash; Checks if a line is too long. &ndash;&gt;-->
+		<!--<property name="max" value="100"/>-->
+		<!--<property name="severity" value="error"/>-->
+
+		<!--&lt;!&ndash;-->
+		<!--The default ignore pattern exempts the following elements:-->
+		<!-- - import statements-->
+		<!-- - long URLs inside comments-->
+		<!--&ndash;&gt;-->
+
+		<!--<property name="ignorePattern"-->
+		<!--value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>-->
+		<!--</module>-->
+
+		<!-- Checks for braces around if and else blocks -->
+		<module name="NeedBraces">
+			<property name="severity" value="error"/>
+			<property name="tokens"
+					  value="LITERAL_IF, LITERAL_ELSE, LITERAL_FOR, LITERAL_WHILE, LITERAL_DO"/>
+		</module>
+
+		<module name="UpperEll">
+			<!-- Checks that long constants are defined with an upper ell.-->
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="FallThrough">
+			<!-- Warn about falling through to the next case statement.  Similar to
+			javac -Xlint:fallthrough, but the check is suppressed if a single-line comment
+			on the last non-blank line preceding the fallen-into case contains 'fall through' (or
+			some other variants that we don't publicized to promote consistency).
+			-->
+			<property name="reliefPattern"
+					  value="fall through|Fall through|fallthru|Fallthru|falls through|Falls through|fallthrough|Fallthrough|No break|NO break|no break|continue on"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!-- Checks for over-complicated boolean expressions. -->
+		<module name="SimplifyBooleanExpression"/>
+
+		<!-- Detects empty statements (standalone ";" semicolon). -->
+		<module name="EmptyStatement"/>
+
+		<!-- Detect multiple consecutive semicolons (e.g. ";;"). -->
+		<module name="RegexpSinglelineJava">
+			<property name="format" value=";{2,}"/>
+			<property name="message" value="Use one semicolon"/>
+			<property name="ignoreComments" value="true"/>
+		</module>
+
+		<!--
+
+		MODIFIERS CHECKS
+
+		-->
+
+		<module name="ModifierOrder">
+			<!-- Warn if modifier order is inconsistent with JLS3 8.1.1, 8.3.1, and
+				 8.4.3.  The prescribed order is:
+				 public, protected, private, abstract, static, final, transient, volatile,
+				 synchronized, native, strictfp
+			  -->
+			<property name="severity" value="error"/>
+		</module>
+
+
+		<!--
+
+		WHITESPACE CHECKS
+
+		-->
+
+		<module name="EmptyLineSeparator">
+			<!-- Checks for empty line separator between tokens. The only
+				 excluded token is VARIABLE_DEF, allowing class fields to
+				 be declared on consecutive lines.
+			-->
+			<property name="allowMultipleEmptyLines" value="false"/>
+			<property name="allowMultipleEmptyLinesInsideClassMembers" value="false"/>
+			<property name="tokens" value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF,
+        INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF,
+        CTOR_DEF"/>
+		</module>
+
+		<module name="WhitespaceAround">
+			<!-- Checks that various tokens are surrounded by whitespace.
+				 This includes most binary operators and keywords followed
+				 by regular or curly braces.
+			-->
+			<property name="tokens" value="ASSIGN, BAND, BAND_ASSIGN, BOR,
+        BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR, BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN,
+        EQUAL, GE, GT, LAMBDA, LAND, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE,
+        LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF, LITERAL_RETURN,
+        LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, LOR, LT, MINUS,
+        MINUS_ASSIGN, MOD, MOD_ASSIGN, NOT_EQUAL, PLUS, PLUS_ASSIGN, QUESTION,
+        SL, SL_ASSIGN, SR_ASSIGN, STAR, STAR_ASSIGN, TYPE_EXTENSION_AND"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="WhitespaceAfter">
+			<!-- Checks that commas, semicolons and typecasts are followed by
+				 whitespace.
+			-->
+			<property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+		</module>
+
+		<module name="NoWhitespaceAfter">
+			<!-- Checks that there is no whitespace after various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="BNOT, DEC, DOT, INC, LNOT, UNARY_MINUS,
+        UNARY_PLUS"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<module name="NoWhitespaceBefore">
+			<!-- Checks that there is no whitespace before various unary operators.
+				 Linebreaks are allowed.
+			-->
+			<property name="tokens" value="SEMI, DOT, POST_DEC, POST_INC"/>
+			<property name="allowLineBreaks" value="true"/>
+			<property name="severity" value="error"/>
+		</module>
+
+		<!--<module name="OperatorWrap">-->
+		<!--&lt;!&ndash; Checks that operators like + and ? appear at newlines rather than-->
+		<!--at the end of the previous line.-->
+		<!--&ndash;&gt;-->
+		<!--<property name="option" value="NL"/>-->
+		<!--<property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL,-->
+		<!--GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD,-->
+		<!--NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR "/>-->
+		<!--</module>-->
+
+		<module name="OperatorWrap">
+			<!-- Checks that assignment operators are at the end of the line. -->
+			<property name="option" value="eol"/>
+			<property name="tokens" value="ASSIGN"/>
+		</module>
+
+		<module name="ParenPad">
+			<!-- Checks that there is no whitespace before close parens or after
+				 open parens.
+			-->
+			<property name="severity" value="error"/>
+		</module>
+
+	</module>
+</module>
+

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+</suppressions>


### PR DESCRIPTION
## What is the purpose of the change

Adding the baseline project structure, Maven pom files and checkstyle configuration

## Brief change log

* Added parent, connector and SQL connector `pom.xml` files
* Adding checkstyle config (from Flink) and empty suppressions file

## Verifying this change

- `mvn clean package` is successfull

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
