### PR TITLE
[FLINK-29246] Rename modules, remove the 'aws' tag inline with repo name

### DIFF
--- a/.github/boring-cyborg.yml
+++ b/.github/boring-cyborg.yml
@@ -25,8 +25,8 @@ labelPRBasedOnFilePath:
     - docs/**/*
 
   component=Connectors/DynamoDB:
-    - flink-connector-aws-dynamodb*/**/*
-    - flink-sql-connector-aws-dynamodb*/**/*
+    - flink-connector-dynamodb*/**/*
+    - flink-sql-connector-dynamodb*/**/*
 
 ###### IssueLink Adder #################################################################################################
 # Insert Issue (Jira/Github etc) link in PR description based on the Issue ID in PR title.

--- a/flink-connector-dynamodb/pom.xml
+++ b/flink-connector-dynamodb/pom.xml
@@ -25,12 +25,12 @@ under the License.
 
     <parent>
         <groupId>org.apache.flink</groupId>
-        <artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+        <artifactId>flink-connector-dynamodb-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>flink-connector-aws-dynamodb</artifactId>
+    <artifactId>flink-connector-dynamodb</artifactId>
     <name>Flink : Connectors : Amazon DynamoDB</name>
 
 	<dependencyManagement>

--- a/flink-sql-connector-dynamodb/pom.xml
+++ b/flink-sql-connector-dynamodb/pom.xml
@@ -25,12 +25,12 @@ under the License.
 
 	<parent>
 		<groupId>org.apache.flink</groupId>
-		<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+		<artifactId>flink-connector-dynamodb-parent</artifactId>
 		<version>1.0.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
-	<artifactId>flink-sql-connector-aws-dynamodb</artifactId>
+	<artifactId>flink-sql-connector-dynamodb</artifactId>
 	<name>Flink : Connectors : SQL : Amazon DynamoDB</name>
 	<packaging>jar</packaging>
 
@@ -48,7 +48,7 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-connector-aws-dynamodb</artifactId>
+			<artifactId>flink-connector-dynamodb</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
@@ -69,8 +69,8 @@ under the License.
 							<artifactSet>
 								<includes>
 									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-aws-base</include>
-									<include>org.apache.flink:flink-connector-aws-dynamodb</include>
+									<include>org.apache.flink:flink-connector-base</include>
+									<include>org.apache.flink:flink-connector-dynamodb</include>
 									<include>software.amazon.awssdk:*</include>
 									<include>org.reactivestreams:*</include>
 									<include>com.typesafe.netty:*</include>
@@ -103,13 +103,13 @@ under the License.
 							</relocations>
 							<filters>
 								<filter>
-									<artifact>org.apache.flink:flink-connector-aws-dynamodb:*</artifact>
+									<artifact>org.apache.flink:flink-connector-dynamodb:*</artifact>
 									<excludes>
 										<exclude>profile</exclude>
 									</excludes>
 								</filter>
 								<filter>
-									<artifact>org.apache.flink:flink-connector-aws-base:*</artifact>
+									<artifact>org.apache.flink:flink-connector-base:*</artifact>
 									<excludes>
 										<exclude>profile</exclude>
 									</excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@ under the License.
 		<relativePath/>
 	</parent>
 
-	<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+	<artifactId>flink-connector-dynamodb-parent</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 
 	<name>Flink : Connectors : Amazon DynamoDB Parent</name>
@@ -58,8 +58,8 @@ under the License.
 	</properties>
 
 	<modules>
-		<module>flink-connector-aws-dynamodb</module>
-		<module>flink-sql-connector-aws-dynamodb</module>
+		<module>flink-connector-dynamodb</module>
+		<module>flink-sql-connector-dynamodb</module>
 	</modules>
 
 	<dependencyManagement>
@@ -97,7 +97,7 @@ under the License.
 							<property>rootDir</property>
 							<project>
 								<groupId>org.apache.flink</groupId>
-								<artifactId>flink-connector-aws-dynamodb-parent</artifactId>
+								<artifactId>flink-connector-dynamodb-parent</artifactId>
 							</project>
 						</configuration>
 					</execution>


### PR DESCRIPTION
## What is the purpose of the change

Rename modules, remove the 'aws' tag inline with repo name

## Brief change log

* Renamed `flink-connector-aws-dynamodb` to `flink-connector-dynamodb`
* Renamed `flink-sql-connector-aws-dynamodb` to `flink-sql-connector-dynamodb`

## Verifying this change

- `mvn clean package` is successfull

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
