### PR TITLE
[FLINK-29310] Added license check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
       matrix:
         jdk: [8, 11]
     env:
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      FLINK_URL: https://dlcdn.apache.org/flink/flink-1.15.2/flink-1.15.2-bin-scala_2.12.tgz
+      MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
+      MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
@@ -45,4 +49,13 @@ jobs:
           maven-version: 3.8.5
 
       - name: Compile and test flink-connector-dynamodb
-        run: mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }}
+        run: mvn clean install -Dflink.convergence.phase=install -Pcheck-convergence -U -B ${{ env.MVN_CONNECTION_OPTIONS }} \
+          -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
+          | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
+
+      - name: Check licensing
+        run: |
+          mvn ${MVN_COMMON_OPTIONS} exec:java@check-licensing -N \
+            -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) $(pwd)" \
+            ${{ env.MVN_CONNECTION_OPTIONS }} \
+            -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,15 @@ under the License.
 		<developerConnection>scm:git:https://gitbox.apache.org/repos/asf/flink-connector-dynamodb.git</developerConnection>
 	</scm>
 
+	<pluginRepositories>
+		<pluginRepository>
+			<!-- Allows exec-maven-plugin to resolve snapshot plugin dependencies -->
+			<id>apache.snapshots.https</id>
+			<name>${distMgmtSnapshotsName}</name>
+			<url>${distMgmtSnapshotsUrl}</url>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<properties>
 		<aws.sdk.version>2.17.247</aws.sdk.version>
 		<flink.version>1.15.2</flink.version>
@@ -83,6 +92,35 @@ under the License.
 
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>exec-maven-plugin</artifactId>
+				<version>3.1.0</version>
+				<inherited>false</inherited>
+				<executions>
+					<execution>
+						<id>check-license</id>
+						<!-- manually called -->
+						<phase>none</phase>
+						<goals>
+							<goal>java</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<mainClass>org.apache.flink.tools.ci.licensecheck.LicenseChecker</mainClass>
+					<includePluginDependencies>true</includePluginDependencies>
+					<includeProjectDependencies>false</includeProjectDependencies>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.apache.flink</groupId>
+						<artifactId>flink-ci-tools</artifactId>
+						<version>1.16-SNAPSHOT</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+
 			<plugin>
 				<!-- Override directory for parent project -->
 				<groupId>org.commonjava.maven.plugins</groupId>

--- a/tools/ci/log4j.properties
+++ b/tools/ci/log4j.properties
@@ -1,0 +1,43 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+rootLogger.level = INFO
+rootLogger.appenderRef.out.ref = ConsoleAppender
+
+# -----------------------------------------------------------------------------
+# Console (use 'console')
+# -----------------------------------------------------------------------------
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
+
+# -----------------------------------------------------------------------------
+# File (use 'file')
+# -----------------------------------------------------------------------------
+appender.file.name = FileAppender
+appender.file.type = FILE
+appender.file.fileName = ${sys:log.dir}/mvn-${sys:mvn.forkNumber:-output}.log
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{HH:mm:ss,SSS} [%20t] %-5p %-60c %x - %m%n
+appender.file.createOnDemand = true
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+logger.netty.name = org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.level = ERROR


### PR DESCRIPTION
Added maven plugin to use in ci workflow for license check.

Note: 
- License check current runs on mvn install directory, which will need to be updated when switched to deploy mode.
- We are using flink-ci-tools dependency which is only available as SNAPSHOT at the moment. https://repository.apache.org/content/repositories/snapshots/org/apache/flink/flink-ci-tools/



Previous closed PR: https://github.com/apache/flink-connector-dynamodb/pull/8. Created new PR to update branch to pull from.